### PR TITLE
Fix favicon file paths

### DIFF
--- a/_includes/favicon.html
+++ b/_includes/favicon.html
@@ -1,5 +1,5 @@
 <!-- Generated using https://favicon.io/ -->
-<link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png?">
-<link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png?">
-<link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png?">
+<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?">
+<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png?">
 <link rel="manifest" href=site.webmanifest">


### PR DESCRIPTION
Favicons dont load on any page but the main page because of the relative paths used in `favicon.html`. This change makes these relative to the root of the page, and is confirmed to work when the root is a domain name with no path.